### PR TITLE
Add RxJS operator D3 graph

### DIFF
--- a/operators.html
+++ b/operators.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RxJS Operators Graph</title>
+  </head>
+  <body>
+    <svg id="graph"></svg>
+    <script type="module" src="/src/operators.ts"></script>
+  </body>
+</html>

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,0 +1,46 @@
+import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7?module'
+
+async function buildGraph() {
+  try {
+    const res = await fetch('https://rxjs.dev/guide/operators')
+    const html = await res.text()
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(html, 'text/html')
+    const anchors = Array.from(doc.querySelectorAll('table td a'))
+    const names = anchors.map(a => a.textContent?.trim()).filter(Boolean) as string[]
+    const nodes = names.map((name, index) => ({ id: index, name }))
+
+    const width = 960
+    const height = 600
+
+    const svg = d3.select('#graph').attr('width', width).attr('height', height)
+
+    const simulation = d3.forceSimulation(nodes as any)
+      .force('charge', d3.forceManyBody().strength(-50))
+      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('collision', d3.forceCollide().radius((d: any) => d.name.length * 4))
+
+    const g = svg.append('g')
+
+    const node = g.selectAll('g')
+      .data(nodes as any)
+      .enter().append('g')
+
+    node.append('circle')
+      .attr('r', (d: any) => d.name.length * 2)
+      .attr('fill', 'lightblue')
+
+    node.append('text')
+      .attr('text-anchor', 'middle')
+      .attr('dy', 4)
+      .text((d: any) => d.name)
+
+    simulation.on('tick', () => {
+      node.attr('transform', (d: any) => `translate(${d.x},${d.y})`)
+    })
+  } catch (err) {
+    console.error('Failed to build graph', err)
+  }
+}
+
+buildGraph()


### PR DESCRIPTION
## Summary
- add a small page that visualizes RxJS operators using D3
- fetch operators from the RxJS docs and create nodes for each

## Testing
- `npm run build` *(fails: Cannot find module 'rxjs' and D3 types)*

------
https://chatgpt.com/codex/tasks/task_e_686646f7b01083309cb5442cfc381edc